### PR TITLE
Add usage tracker to GPT by price

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   push_to_registry:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY . /app
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir --user Flask Flask_cors PyYAML openai waitress
+    pip install --no-cache-dir --user -r requirements.txt
 
 # Runtime stage
 FROM python:3.9-slim as runtime

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ ASK_QUERY=$(sed "s/ /%20/g" <<<"$ASK_QUERY") # encodes whitespaces
 curl "http://localhost:5003/ask_chat?query=$ASK_QUERY"
 ```
 
+## Deployment settings
+
+Environment variables used in the server:
+
+- `WEB5GPT_MONTHLY_USAGE_LIMIT_USD` - sets the monthly usage limit in USD for the `/ask_chat` endpoint. The service actually just set a daily limit by dividing this number by 30. By default this is $500/30 = ~$16.66 per day.
+- `OPENAI_API_KEY` - define the OpenAI API Key
+
 ## Getting help
 
 If you run into issues or have questions building a plugin, please join our [Developer community forum](https://community.openai.com/c/chat-plugins/20).

--- a/README.md
+++ b/README.md
@@ -30,15 +30,27 @@ To run the plugin, enter the following command:
 python main.py
 ```
 
-Once the local server is running:
+Once the local server is running...
 
-1. Navigate to https://chat.openai.com. 
+### Test the ChatGPT Plugin
+
+1. Navigate to https://chat.openai.com.
 2. In the Model drop down, select "Plugins" (note, if you don't see it there, you don't have access yet).
 3. Select "Plugin store"
 4. Select "Develop your own plugin"
 5. Enter in `localhost:5003` since this is the URL the server is running on locally, then select "Find manifest file".
 
-The plugin should now be installed and enabled! You can start with a question like "What is on my todo list" and then try adding something to it as well! 
+The plugin should now be installed and enabled! You can start with a question like "What is on my todo list" and then try adding something to it as well!
+
+### Test the Ask GPT feature from developer.tbd.website
+
+Execute the following curl requests:
+
+```sh
+ASK_QUERY="How to connect to web5 and create a record?"
+ASK_QUERY=$(sed "s/ /%20/g" <<<"$ASK_QUERY") # encodes whitespaces
+curl "http://localhost:5003/ask_chat?query=$ASK_QUERY"
+```
 
 ## Getting help
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ ASK_QUERY=$(sed "s/ /%20/g" <<<"$ASK_QUERY") # encodes whitespaces
 curl "http://localhost:5003/ask_chat?query=$ASK_QUERY"
 ```
 
+## Running with Docker
+
+1. Install docker on your computer
+2. Set the OPENAI_API_KEY in the `docker-compose.yaml` file
+3. Execute `docker compose up`
+
 ## Deployment settings
 
 Environment variables used in the server:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "5003:5003"
+    environment:
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      WEB5GPT_MONTHLY_USAGE_LIMIT_USD: 30

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask-cors
 PyYAML
 openai
 waitress
+tiktoken

--- a/usage_cost_tracker.py
+++ b/usage_cost_tracker.py
@@ -1,0 +1,111 @@
+import datetime
+import tiktoken
+import os
+from openai.types.chat import ChatCompletion
+
+MONTHLY_USAGE_LIMIT_USD = os.getenv("WEB5GPT_MONTHLY_USAGE_LIMIT_USD")
+
+TOTAL_DAILY_COST_LIMIT = 500.0 / 30.0
+
+# Pricing rates updated on 2023-12-19
+MODELS_COSTS = {
+    "gpt-3.5-turbo-16k": { "price_per_thousand_tokens": { "input": 0.001, "output": 0.0020 } },
+    "gpt-4-1106-preview": { "price_per_thousand_tokens": { "input": 0.01, "output": 0.03 } },
+}
+
+class UsageCostTracker:
+    def __init__(self):
+        self.current_date = None
+        self.daily_usage_cost = 0.0
+        self.tokenizer = tiktoken.get_encoding("cl100k_base")
+
+        # initialize monthly usage limit in USD
+        if MONTHLY_USAGE_LIMIT_USD:
+            self.total_daily_cost_limit = float(MONTHLY_USAGE_LIMIT_USD) / 30.0
+        else:
+            self.total_daily_cost_limit = TOTAL_DAILY_COST_LIMIT
+        print(">>> Total daily cost limit: $%.2f" % self.total_daily_cost_limit)
+
+    def check_usage_costs(self):
+        today = datetime.datetime.now().date()
+
+        # Reset the daily usage cost if it's a new day
+        if self.current_date != today:
+            self.daily_usage_cost = 0.0
+            self.current_date = today
+
+        # Check if the daily usage cost has exceeded the limit
+        if self.daily_usage_cost >= self.total_daily_cost_limit:
+            raise Exception(f">>> ERROR! Daily usage cost ${self.daily_usage_cost:.2f} exceeded limit of ${self.total_daily_cost_limit:.2f}")
+        
+    def compute_response_costs(self, response: ChatCompletion):
+        if not response.usage or not response.model:
+            print(">>> WARNING! No model/usage in response, impossible to compute costs")
+            return
+        
+        response_model = response.model
+        if response_model not in MODELS_COSTS:
+            print(">>> WARNING! Model not found in MODELS_COSTS, impossible to compute costs")
+            return
+
+        model_costs = MODELS_COSTS[response_model]
+
+        print(">>> Computing costs for Model: %s" % response_model)
+
+        price_per_thousand_tokens = model_costs["price_per_thousand_tokens"]
+        input_cost = calculate_tokens_cost(response.usage.prompt_tokens, price_per_thousand_tokens["input"])
+        output_cost = calculate_tokens_cost(response.usage.completion_tokens, price_per_thousand_tokens["output"])
+        total_cost = input_cost + output_cost
+        print(">>> Total cost: $%.4f" % total_cost)
+
+        self.daily_usage_cost += total_cost
+        print(">>> Current Daily usage cost: $%.4f (of $%.2f)" % (self.daily_usage_cost, self.total_daily_cost_limit))
+
+
+    def compute_messages_cost(self, messages, model_name):
+        tokens_per_message = 3
+        tokens_per_name = 1
+        num_tokens = 0
+        
+        for message in messages:
+            num_tokens += tokens_per_message
+            for key, value in message.items():
+                num_tokens += self.count_tokens(value)
+                if key == "name":
+                    num_tokens += tokens_per_name
+        
+        num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>
+        
+        self.compute_tokens_cost(num_tokens, model_name)
+
+
+    def compute_stream_cost(self, chunk, model_name):
+        token_count = self.count_tokens(chunk)
+
+        # Assuming the chunk is the response content
+        self.compute_tokens_cost(token_count, model_name, is_output=True)
+
+
+    def compute_tokens_cost(self, tokens, model_name, is_output=False):
+        if model_name not in MODELS_COSTS:
+            print(">>> WARNING! Model not found in MODELS_COSTS, impossible to compute costs")
+            return
+
+        model_costs = MODELS_COSTS[model_name]
+        input_type = "output" if is_output else "input"
+        price_per_thousand_tokens = model_costs["price_per_thousand_tokens"][input_type]
+
+        usage_cost = calculate_tokens_cost(tokens, price_per_thousand_tokens)
+
+        self.daily_usage_cost += usage_cost
+        print(f">>> Added cost: ${usage_cost:.4f}, New daily usage: ${self.daily_usage_cost:.4f} (of ${self.total_daily_cost_limit:.2f})")
+
+    def count_tokens(self, text):  
+        return len(self.tokenizer.encode(text))
+
+
+
+def calculate_tokens_cost(tokens, price_per_thousand_tokens):
+    cost_per_token = price_per_thousand_tokens / 1000
+    return cost_per_token * tokens
+    

--- a/usage_cost_tracker.py
+++ b/usage_cost_tracker.py
@@ -81,13 +81,6 @@ class UsageCostTracker:
         self.compute_tokens_cost(num_tokens, model_name)
 
 
-    def compute_stream_cost(self, chunk, model_name):
-        token_count = self.count_tokens(chunk)
-
-        # Assuming the chunk is the response content
-        self.compute_tokens_cost(token_count, model_name, is_output=True)
-
-
     def compute_tokens_cost(self, tokens, model_name, is_output=False):
         if model_name not in MODELS_COSTS:
             print(">>> WARNING! Model not found in MODELS_COSTS, impossible to compute costs")


### PR DESCRIPTION
Three caveats here:
- The pricing per token usage is hardcoded from what I got in the OpenAI website today
- The calculation of the stream chunks is an approximate calculation using tiktoken (official tokenizer by OpenAI)
  - This is a super requested feature as you can see here: https://community.openai.com/t/openai-api-get-usage-tokens-in-response-when-set-stream-true/141866/1
- We check for the cost limit before the prompts execution, so if its a huge request prompt it might pass the limit by a few cents.